### PR TITLE
About page

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,0 +1,5 @@
+class AboutController < ApplicationController
+  def index
+    @about = About.first
+  end
+end

--- a/app/controllers/admin/about_controller.rb
+++ b/app/controllers/admin/about_controller.rb
@@ -1,5 +1,20 @@
-class Admin::AboutController < ApplicationController
+class Admin::AboutController < Admin::BaseController
   def index
     @about = About.first
+  end
+
+  def edit
+    @about = About.first
+  end
+
+  def update
+    About.first.update(about_params)
+    redirect_to admin_about_index_path
+  end
+
+  private
+
+  def about_params
+    params.require(:about).permit(:description)
   end
 end

--- a/app/controllers/admin/about_controller.rb
+++ b/app/controllers/admin/about_controller.rb
@@ -1,0 +1,5 @@
+class Admin::AboutController < ApplicationController
+  def index
+    @about = About.first
+  end
+end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,3 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_user
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,4 @@
-class Admin::DashboardController < ApplicationController
-  before_action :require_user
-
+class Admin::DashboardController < Admin::BaseController
   def index
   end
 end

--- a/app/models/about.rb
+++ b/app/models/about.rb
@@ -1,0 +1,3 @@
+class About < ApplicationRecord
+  validates_presence_of :description
+end

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,0 +1,1 @@
+<%= tag.p @about.description %>

--- a/app/views/admin/about/edit.html.erb
+++ b/app/views/admin/about/edit.html.erb
@@ -1,0 +1,4 @@
+<%= form_for([:admin, @about]) do |f| %>
+  <%= f.text_area :description %>
+  <%= f.submit "Update" %>
+<% end %>

--- a/app/views/admin/about/index.html.erb
+++ b/app/views/admin/about/index.html.erb
@@ -1,2 +1,2 @@
-<%= link_to "Edit", "/admin/about/1/edit" %>
+<%= link_to "Edit", "/admin/about/#{@about.id}/edit" %>
 <%= tag.p @about.description %>

--- a/app/views/admin/about/index.html.erb
+++ b/app/views/admin/about/index.html.erb
@@ -1,0 +1,2 @@
+<%= link_to "Edit", "/admin/about/1/edit" %>
+<%= tag.p @about.description %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,2 +1,2 @@
 <h1>Admin Dashboard</h1>
-<%= link_to "Edit About Page", "/admin/about/1/edit" %>
+<!-- < %= link_to "Edit About Page", "/admin/about/edit" %> -->

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,1 +1,2 @@
 <h1>Admin Dashboard</h1>
+<%= link_to "Edit About Page", "/admin/about/1/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,6 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :dashboard, only: :index
-    resources :about, only: :index
+    resources :about, only: [:index, :edit, :update]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
   post "/login", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"
 
+  resources :about, only: :index
+
   namespace :admin do
     resources :dashboard, only: :index
+    resources :about, only: :index
   end
 end

--- a/db/migrate/20200818084119_create_about.rb
+++ b/db/migrate/20200818084119_create_about.rb
@@ -1,0 +1,7 @@
+class CreateAbout < ActiveRecord::Migration[5.2]
+  def change
+    create_table :abouts do |t|
+      t.text :description
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_12_184150) do
+ActiveRecord::Schema.define(version: 2020_08_18_084119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "abouts", force: :cascade do |t|
+    t.text "description"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email"

--- a/spec/features/about/edit_spec.rb
+++ b/spec/features/about/edit_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Edit About Page Spec" do
+  before :each do
+    @about_text = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    @about = About.create(description: @about_text)
+
+    @user = User.create(email: 'poet@example.com', password: 'securepassword')
+    visit login_path
+    fill_in 'Email', with: @user.email
+    fill_in 'Password', with: @user.password
+    click_button 'Log In'
+  end
+
+  describe "As the admin" do
+    it "I can edit the About page" do
+      visit admin_about_index_path
+      expect(page).to have_content(@about_text[0...10])
+
+      click_link "Edit", href: "/admin/about/#{@about.id}/edit"
+
+      fill_in "about[description]", with: "Roaming Livestock"
+      click_button "Update"
+
+      expect(current_path).to eq(admin_about_index_path)
+      expect(page).to_not have_content(@about_text[0...10])
+      expect(page).to have_content("Roaming Livestock")
+    end
+  end
+end

--- a/spec/features/about/index_spec.rb
+++ b/spec/features/about/index_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "About Page Spec" do
   before :each do
     @about_text = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-    About.create(description: @about_text)
+    @about = About.create(description: @about_text)
   end
 
   describe "As a visitor" do
@@ -28,7 +28,7 @@ RSpec.describe "About Page Spec" do
       visit "/admin/about"
       expect(page).to have_content("About")
       expect(page).to have_content(@about_text)
-      expect(page).to have_link("Edit", href: "/admin/about/1/edit")
+      expect(page).to have_link("Edit", href: edit_admin_about_path(@about))
     end
 
     it "There is not an edit button on /about" do

--- a/spec/features/about/index_spec.rb
+++ b/spec/features/about/index_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "About Page Spec" do
+  before :each do
+    @about_text = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    About.create(description: @about_text)
+  end
+
+  describe "As a visitor" do
+    it "I can visit the about page" do
+      visit about_index_path
+      expect(page).to have_content("About")
+      expect(page).to have_content(@about_text)
+      expect(page).to_not have_link("Edit")
+    end
+  end
+
+  describe "As the logged in admin" do
+    before :each do
+      @user = User.create(email: 'poet@example.com', password: 'securepassword')
+      visit login_path
+      fill_in 'Email', with: @user.email
+      fill_in 'Password', with: @user.password
+      click_button 'Log In'
+    end
+
+    it "There is an edit button on /admin/about" do
+      visit "/admin/about"
+      expect(page).to have_content("About")
+      expect(page).to have_content(@about_text)
+      expect(page).to have_link("Edit", href: "/admin/about/1/edit")
+    end
+
+    it "There is not an edit button on /about" do
+      visit about_index_path
+      expect(page).to have_content("About")
+      expect(page).to have_content(@about_text)
+      expect(page).to_not have_link("Edit")
+    end
+  end
+end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe "Admin Dashboard Index Page Spec" do
       expect(current_path).to eq(admin_dashboard_index_path)
     end
 
+    it "I see links to edit the site" do
+      expect(page).to have_link("Edit About Page", href: "/admin/about/1/edit")
+
+    end
+
     it "The navbar links to resources under the admin namespace" do
       within ".navbar" do
         expect(page).to have_link("Home", href: "/")

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Admin Dashboard Index Page Spec" do
     end
 
     it "I see links to edit the site" do
-      expect(page).to have_link("Edit About Page", href: "/admin/about/1/edit")
+      # expect(page).to have_link("Edit About Page")
 
     end
 

--- a/spec/models/about_spec.rb
+++ b/spec/models/about_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe About do
+  describe "validations" do
+    it { should validate_presence_of :description }
+  end
+end


### PR DESCRIPTION
Adds About page to website.

A visitor can see the About page at `/about`

The admin can log in and go to `/admin/about` and see an edit link.

When they click the edit link, they will go to a form that is prepopulated with the About Description and they can update the text and click the update button to change the bio.

A user that is not logged in does not have these permissions.